### PR TITLE
Allow ModulesInfo to return all focus area strings for later use in creating default tags

### DIFF
--- a/src/main/java/seedu/address/model/ModuleInfo.java
+++ b/src/main/java/seedu/address/model/ModuleInfo.java
@@ -51,6 +51,14 @@ public class ModuleInfo {
         return this.code;
     }
 
+    public List<String> getFocusPrimaries() {
+        return this.focusPrimaries;
+    }
+
+    public List<String> getFocusElectives() {
+        return this.focusElectives;
+    }
+
     /**
      * Returns a String displaying all information about the module, in a human-readable format.
      */

--- a/src/main/java/seedu/address/model/ModulesInfo.java
+++ b/src/main/java/seedu/address/model/ModulesInfo.java
@@ -2,6 +2,7 @@ package seedu.address.model;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 
 /**
@@ -52,6 +53,25 @@ public class ModulesInfo {
             return false;
         }
         return moduleInfo.verify(prevSemModuleCodes);
+    }
+
+    /**
+     * Returns a list of all focus area names. Does not differentiate between electives and primaries.
+     * This method call could be expensive, so it's not meant to be called many times.
+     */
+    public HashSet<String> getFocusAreaNames() {
+        HashSet<String> set = new HashSet<>();
+        for (ModuleInfo moduleInfo : this.modulesInfo) {
+            List<String> focusPrimaries = moduleInfo.getFocusPrimaries();
+            List<String> focusElectives = moduleInfo.getFocusElectives();
+            for (String focusPrimary : focusPrimaries) {
+                set.add(focusPrimary);
+            }
+            for (String focusElective : focusElectives) {
+                set.add(focusElective);
+            }
+        }
+        return set;
     }
 
     @Override

--- a/src/test/java/seedu/address/model/ModulesInfoTest.java
+++ b/src/test/java/seedu/address/model/ModulesInfoTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.testutil.TypicalModulesInfo.CS2040S;
 import static seedu.address.testutil.TypicalModulesInfo.getTypicalModulesInfo;
 
+import java.util.HashSet;
+
 import org.junit.jupiter.api.Test;
 
 public class ModulesInfoTest {
@@ -26,5 +28,14 @@ public class ModulesInfoTest {
     public void find_validModuleCode_returnsModuleInfo() {
         ModuleInfo moduleInfo = modulesInfo.find("CS2040S");
         assertEquals(moduleInfo, CS2040S);
+    }
+
+    @Test
+    public void getFocusAreaNames_returnsAllNames() {
+        HashSet<String> set = modulesInfo.getFocusAreaNames();
+        HashSet<String> expectedSet = new HashSet<>();
+        expectedSet.add("AI");
+        expectedSet.add("MIR");
+        assertEquals(set, expectedSet);
     }
 }


### PR DESCRIPTION
Added the method`getFocusAreaNames()` to `ModulesInfo`, which returns a `HashSet<String>` of all focus area names. To be used by `StudyPlan` to initialise modules and default tags.