### PR TITLE
Add get module info hashmap

### DIFF
--- a/src/main/java/seedu/address/model/ModulesInfo.java
+++ b/src/main/java/seedu/address/model/ModulesInfo.java
@@ -22,6 +22,10 @@ public class ModulesInfo {
         this.mapModulesInfo = modulesInfo;
     }
 
+    public HashMap<String, ModuleInfo> getModuleInfoHashMap() {
+        return this.mapModulesInfo;
+    }
+
     /**
      * Initialises by reading {@code modulesInfo} into #{@code mapModulesInfo}.
      * Parses the prerequisite tree for all modules with information.


### PR DESCRIPTION
To `ModulesInfo`, add a new method `getModuleInfoHashMap()` -- returns a `HashMap<String, ModuleInfo>` where keys are module codes, values are `ModuleInfo`