### PR TITLE
Fix null error for updatePrereqs

### DIFF
--- a/src/main/java/seedu/address/model/ModulePlanner.java
+++ b/src/main/java/seedu/address/model/ModulePlanner.java
@@ -268,8 +268,13 @@ public class ModulePlanner implements ReadOnlyModulePlanner {
         return modulesInfo;
     }
 
+    /**
+     * Updates prerequisites of the active study plan, if it exists.
+     */
     public void updatePrereqs() {
-        this.activeStudyPlan.updatePrereqs();
+        if (this.activeStudyPlan != null) {
+            this.activeStudyPlan.updatePrereqs();
+        }
     }
 
     public void changeActiveStudyPlanTitle(String title) {


### PR DESCRIPTION
`updatePrereqs()` should not give null pointer exception anymore, it checks if `activeStudyPlan` is null

(but there are still even more null pointer exceptions if you try to delete all study plans, not related to this)